### PR TITLE
Improve trading agent

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7,7 +7,16 @@ import asyncio
 
 from sources.llm_provider import Provider
 from sources.interaction import Interaction
-from sources.agents import Agent, CoderAgent, CasualAgent, FileAgent, PlannerAgent, BrowserAgent, McpAgent
+from sources.agents import (
+    Agent,
+    CoderAgent,
+    CasualAgent,
+    FileAgent,
+    PlannerAgent,
+    BrowserAgent,
+    McpAgent,
+    TradingAgent,
+)
 from sources.browser import Browser, create_driver
 from sources.utility import pretty_print
 
@@ -34,21 +43,44 @@ async def main():
     )
 
     agents = [
-        CasualAgent(name=config["MAIN"]["agent_name"],
-                    prompt_path=f"prompts/{personality_folder}/casual_agent.txt",
-                    provider=provider, verbose=False),
-        CoderAgent(name="coder",
-                   prompt_path=f"prompts/{personality_folder}/coder_agent.txt",
-                   provider=provider, verbose=False),
-        FileAgent(name="File Agent",
-                  prompt_path=f"prompts/{personality_folder}/file_agent.txt",
-                  provider=provider, verbose=False),
-        BrowserAgent(name="Browser",
-                     prompt_path=f"prompts/{personality_folder}/browser_agent.txt",
-                     provider=provider, verbose=False, browser=browser),
-        PlannerAgent(name="Planner",
-                     prompt_path=f"prompts/{personality_folder}/planner_agent.txt",
-                     provider=provider, verbose=False, browser=browser),
+        CasualAgent(
+            name=config["MAIN"]["agent_name"],
+            prompt_path=f"prompts/{personality_folder}/casual_agent.txt",
+            provider=provider,
+            verbose=False,
+        ),
+        CoderAgent(
+            name="coder",
+            prompt_path=f"prompts/{personality_folder}/coder_agent.txt",
+            provider=provider,
+            verbose=False,
+        ),
+        FileAgent(
+            name="File Agent",
+            prompt_path=f"prompts/{personality_folder}/file_agent.txt",
+            provider=provider,
+            verbose=False,
+        ),
+        BrowserAgent(
+            name="Browser",
+            prompt_path=f"prompts/{personality_folder}/browser_agent.txt",
+            provider=provider,
+            verbose=False,
+            browser=browser,
+        ),
+        PlannerAgent(
+            name="Planner",
+            prompt_path=f"prompts/{personality_folder}/planner_agent.txt",
+            provider=provider,
+            verbose=False,
+            browser=browser,
+        ),
+        TradingAgent(
+            name="CoBax T",
+            prompt_path=f"prompts/{personality_folder}/trading_agent.txt",
+            provider=provider,
+            verbose=False,
+        ),
         #McpAgent(name="MCP Agent",
         #            prompt_path=f"prompts/{personality_folder}/mcp_agent.txt",
         #            provider=provider, verbose=False), # NOTE under development

--- a/prompts/base/trading_agent.txt
+++ b/prompts/base/trading_agent.txt
@@ -1,0 +1,1 @@
+You are CoBax T, a cryptocurrency trading assistant. Keep responses short and provide up-to-date market information when asked about a trading pair.

--- a/prompts/jarvis/trading_agent.txt
+++ b/prompts/jarvis/trading_agent.txt
@@ -1,0 +1,1 @@
+You are CoBax T, a cryptocurrency trading assistant. Reply with concise market data when asked about crypto prices.

--- a/sources/agents/__init__.py
+++ b/sources/agents/__init__.py
@@ -6,5 +6,15 @@ from .file_agent import FileAgent
 from .planner_agent import PlannerAgent
 from .browser_agent import BrowserAgent
 from .mcp_agent import McpAgent
+from .trading_agent import TradingAgent
 
-__all__ = ["Agent", "CoderAgent", "CasualAgent", "FileAgent", "PlannerAgent", "BrowserAgent", "McpAgent"]
+__all__ = [
+    "Agent",
+    "CoderAgent",
+    "CasualAgent",
+    "FileAgent",
+    "PlannerAgent",
+    "BrowserAgent",
+    "McpAgent",
+    "TradingAgent",
+]

--- a/sources/agents/trading_agent.py
+++ b/sources/agents/trading_agent.py
@@ -1,0 +1,108 @@
+import os
+import time
+import hmac
+import hashlib
+from typing import List, Tuple
+
+import requests
+
+from sources.agents.agent import Agent
+from sources.memory import Memory
+
+class TradingAgent(Agent):
+    """Basic cryptocurrency trading agent using Binance public API."""
+    def __init__(self, name, prompt_path, provider, verbose=False):
+        super().__init__(name, prompt_path, provider, verbose)
+        self.role = "trading"
+        self.type = "trading_agent"
+        self.base_url = "https://api.binance.com"
+        self.api_key = os.getenv("BINANCE_API_KEY", "")
+        self.api_secret = os.getenv("BINANCE_API_SECRET", "")
+        self.memory = Memory(
+            self.load_prompt(prompt_path),
+            recover_last_session=False,
+            memory_compression=False,
+            model_provider=provider.get_model_name(),
+        )
+
+    def fetch_price(self, symbol: str) -> str:
+        """Return latest price for given symbol."""
+        endpoint = f"{self.base_url}/api/v3/ticker/price"
+        resp = requests.get(endpoint, params={"symbol": symbol.upper()}, timeout=10)
+        resp.raise_for_status()
+        return resp.json()["price"]
+
+    def fetch_klines(self, symbol: str, interval: str = "1h", limit: int = 24) -> List[Tuple[float, float]]:
+        """Return klines (open time, close price) for a symbol."""
+        endpoint = f"{self.base_url}/api/v3/klines"
+        params = {"symbol": symbol.upper(), "interval": interval, "limit": limit}
+        resp = requests.get(endpoint, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        return [(float(d[0]), float(d[4])) for d in data]
+
+    @staticmethod
+    def moving_average(data: List[Tuple[float, float]]) -> float:
+        """Compute simple moving average from kline close prices."""
+        if not data:
+            return 0.0
+        return sum(price for _, price in data) / len(data)
+
+    def determine_trade_signal(self, symbol: str) -> str:
+        """Return a simple buy/sell signal using last price vs MA."""
+        klines = self.fetch_klines(symbol)
+        current_price = float(self.fetch_price(symbol))
+        ma = self.moving_average(klines)
+        return "buy" if current_price > ma else "sell"
+
+    def _sign_params(self, params: dict) -> dict:
+        """Sign parameters for Binance order endpoints."""
+        if not self.api_key or not self.api_secret:
+            raise RuntimeError("Missing Binance API credentials")
+        params["timestamp"] = int(time.time() * 1000)
+        query = "&".join([f"{k}={v}" for k, v in sorted(params.items())])
+        signature = hmac.new(self.api_secret.encode(), query.encode(), hashlib.sha256).hexdigest()
+        params["signature"] = signature
+        return params
+
+    def place_order(self, symbol: str, side: str, quantity: float) -> str:
+        """Place a test order using Binance API."""
+        endpoint = f"{self.base_url}/api/v3/order/test"
+        params = self._sign_params({"symbol": symbol.upper(), "side": side.upper(), "type": "MARKET", "quantity": quantity})
+        headers = {"X-MBX-APIKEY": self.api_key}
+        resp = requests.post(endpoint, params=params, headers=headers, timeout=10)
+        resp.raise_for_status()
+        return "Order placed"
+
+    async def process(self, prompt, speech_module):
+        self.memory.push("user", prompt)
+        parts = prompt.strip().split()
+        if len(parts) == 0:
+            return "No command", ""
+
+        cmd = parts[0].lower()
+        if cmd == "test" and len(parts) >= 2:
+            symbol = parts[1]
+            signal = self.determine_trade_signal(symbol)
+            answer = f"Test signal for {symbol}: {signal}"
+        elif cmd == "trade" and len(parts) >= 3:
+            symbol = parts[1]
+            qty = float(parts[2])
+            try:
+                resp = self.place_order(symbol, "BUY", qty)
+                answer = resp
+            except Exception as exc:
+                answer = f"Trade error: {exc}"
+        else:
+            symbol = parts[0]
+            try:
+                price = self.fetch_price(symbol)
+                answer = f"Current price of {symbol.upper()} is {price} USDT."
+            except Exception as exc:
+                answer = f"Error fetching price for {symbol}: {exc}"
+
+        self.last_answer = answer
+        self.memory.push("assistant", answer)
+        self.status_message = "Ready"
+        return answer, ""
+

--- a/tests/test_trading_agent.py
+++ b/tests/test_trading_agent.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest.mock import patch
+
+from sources.agents.trading_agent import TradingAgent
+
+class TestTradingAgent(unittest.TestCase):
+    def setUp(self):
+        self.agent = TradingAgent(
+            name="TestTrader",
+            prompt_path="prompts/base/trading_agent.txt",
+            provider=None,
+        )
+
+    @patch("sources.agents.trading_agent.requests.get")
+    def test_fetch_price(self, mock_get):
+        mock_get.return_value.json.return_value = {"price": "100.0"}
+        mock_get.return_value.raise_for_status.return_value = None
+        price = self.agent.fetch_price("BTCUSDT")
+        self.assertEqual(price, "100.0")
+
+    @patch("sources.agents.trading_agent.requests.get")
+    def test_determine_trade_signal(self, mock_get):
+        klines_data = [[0, 0, 0, 0, "90"]] * 24
+        responses = [
+            {"json": lambda: {"price": "100"}},
+            {"json": lambda: klines_data},
+        ]
+        def side_effect(url, params=None, timeout=10):
+            resp = unittest.mock.MagicMock()
+            data = responses.pop(0)
+            resp.json = data["json"]
+            resp.raise_for_status.return_value = None
+            return resp
+        mock_get.side_effect = side_effect
+        signal = self.agent.determine_trade_signal("BTCUSDT")
+        self.assertEqual(signal, "buy")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand `TradingAgent` with price history retrieval and order placement stubs
- record Binance API credentials from environment variables
- add a test suite for the trading agent

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_b_6840516e5cb483258208233ce1caf04a